### PR TITLE
Small bug fix

### DIFF
--- a/lib/bones/plugins/gem.rb
+++ b/lib/bones/plugins/gem.rb
@@ -135,7 +135,7 @@ module Bones::Plugins::Gem
       if config.gem._spec.nil?
         config.gem._spec = Gem::Specification.new do |s|
           s.name = config.name
-          s.version = config.version
+          s.version = config.version.dup
           s.summary = config.summary
           s.authors = Array(config.authors)
           s.email = config.email


### PR DESCRIPTION
Don't know if it is the version of ruby I am running or what, but when I run the gem:release command, I get errors involving trying to modify a frozen string.  I think it has to do with taking values from the ENV hash, which in my version of ruby are frozen.
