### PR TITLE
Make bones work with Rake >= 0.9.0

### DIFF
--- a/lib/bones/helpers.rb
+++ b/lib/bones/helpers.rb
@@ -1,5 +1,6 @@
 
 module Bones::Helpers
+  include Rake::DSL if defined?(Rake::DSL)
   extend self
 
   DEV_NULL = File.exist?('/dev/null') ? '/dev/null' : 'NUL:'


### PR DESCRIPTION
Rake no longer puts its DSL methods in the Object class since version 0.9.0. To access them it is necessary to mixin `Rake::DSL`.

Solves issue #18.
