### PR TITLE
Update spec helper template to RSpec 2

### DIFF
--- a/default/spec/spec_helper.rb.bns
+++ b/default/spec/spec_helper.rb.bns
@@ -2,14 +2,14 @@
 require File.expand_path(
     File.join(File.dirname(__FILE__), %w[.. lib <%= name %>]))
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   # == Mock Framework
   #
   # RSpec uses it's own mocking framework by default. If you prefer to
   # use mocha, flexmock or RR, uncomment the appropriate line:
   #
-  # config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
+  # config.mock_framework = :mocha
+  # config.mock_framework = :flexmock
+  # config.mock_framework = :rr
 end
 


### PR DESCRIPTION
The `spec_helper.rb` template is still using RSpec 1.x and generates quite a bit of warnings. New projects are likely to use RSpec 2 only.
