### PR TITLE
Use git rules for lines in that start with `/` in .gitignore

### DIFF
--- a/lib/bones/plugins/gem.rb
+++ b/lib/bones/plugins/gem.rb
@@ -315,6 +315,7 @@ module Bones::Plugins::Gem
         next if line =~ comment
         line.chomp!
         line.strip!
+        line.sub! %r{^/}, ''
         next if line.nil? or line.empty?
 
         glob = line =~ %r/\*\./ ? File.join('**', line) : line


### PR DESCRIPTION
In `.gitignore` a rule like

```
/dir/
```

makes git ignore only the directory named `dir` that is in the top level, not all the directories named `dir`. While it would be hard for Bones to have exactly the same behaviour, this patch simulates how git would behave in the case of a `/dir/` line.
