### PR TITLE
Use `RbConfig` instead of `Config` for compatibility with Ruby 1.9

### DIFF
--- a/lib/bones.rb
+++ b/lib/bones.rb
@@ -19,8 +19,8 @@ module Bones
   HOME = File.expand_path(ENV['HOME'] || ENV['USERPROFILE'])
 
   # Ruby Interpreter location - taken from Rake source code
-  RUBY = File.join(Config::CONFIG['bindir'],
-                   Config::CONFIG['ruby_install_name']).sub(/.*\s.*/m, '"\&"')
+  RUBY = File.join(RbConfig::CONFIG['bindir'],
+                   RbConfig::CONFIG['ruby_install_name']).sub(/.*\s.*/m, '"\&"')
 
   module Plugins; end
   # :startdoc:


### PR DESCRIPTION
This fixes the following warning in Ruby 1.8.x and Ruby 1.9.3

```
lib/bones.rb:22: Use RbConfig instead of obsolete and deprecated Config.
```

`RbConfig` is available also in 1.8.7 so this change should raise any compatibility issue.
