### PR TITLE
Don't import rdoc options from gemspec if rdoc plugin isn't loaded

### DIFF
--- a/lib/bones/plugins/gem.rb
+++ b/lib/bones/plugins/gem.rb
@@ -358,7 +358,9 @@ module Bones::Plugins::Gem
     config.rubyforge_project  = spec.rubyforge_project
 
     config.gem.executables    = spec.executables
-    config.rdoc.opts          = spec.rdoc_options
+    if have? :rdoc
+      config.rdoc.opts        = spec.rdoc_options
+    end
     config.test.file          = spec.test_file if spec.test_file
     config.test.files         = spec.test_files if spec.test_files
 


### PR DESCRIPTION
If we choose to disregard the rdoc plugin and we tell Mr Bones to import an
existing gemspec, then Loquacious will display a warning like this:

```
---------------------------------------------------------------------------
The Loquacious configuration system has detected that one or moe
settings have an undefined value. An attempt is being made to reference
sub-properties of these undefined settings. Messages will follow containing
information about the undefined properties.
---------------------------------------------------------------------------
Access to undefined value "rdoc": rdoc.opts=
```

This is because the rdoc plugin adds rdoc.opts to the global config object. So,
we merely check that the rdoc plugin has been loaded before attempting to set
this option.
