### PR TITLE
handle the RubyGems 2.0.0 case per #36

### DIFF
--- a/lib/bones/gem_package_task.rb
+++ b/lib/bones/gem_package_task.rb
@@ -2,7 +2,11 @@
 require 'find'
 require 'rake/packagetask'
 require 'rubygems/user_interaction'
-require 'rubygems/builder'
+if RUBY_VERSION >= "2"
+  require 'rubygems/package'
+else
+  require 'rubygems/builder'
+end
 
 class Bones::GemPackageTask < Rake::PackageTask
 


### PR DESCRIPTION
This patch has been tested with Ruby 1.8.7, 1.9.3, and 2.0 and all specs pass on each of them.
