### PR TITLE
Update gem_package_task.rb

### DIFF
--- a/lib/bones/gem_package_task.rb
+++ b/lib/bones/gem_package_task.rb
@@ -1,8 +1,7 @@
-
 require 'find'
 require 'rake/packagetask'
 require 'rubygems/user_interaction'
-if RUBY_VERSION >= "2"
+if RUBY_VERSION.match(/(\d+\.\d+)/)[1].to_f >= 1.9
   require 'rubygems/package'
 else
   require 'rubygems/builder'


### PR DESCRIPTION
Check for RUBY_VERSION >= "2" is invalid, some earlier versions (e.g. 1.9) of ruby cannot use
rubygems/builder.
Avoid this error when using ruby 1.9 or jruby versions that act as 1.9:
    no such file to load -- rubygems/builder
This problem will appear as soon as the user's rake file does:
    require 'bones'
Problem appears in Jruby 1.7.5 using bones version 3.8.1
