### PR TITLE
try loading rubygems' package than fallback to builder

### DIFF
--- a/lib/bones/gem_package_task.rb
+++ b/lib/bones/gem_package_task.rb
@@ -2,9 +2,9 @@
 require 'find'
 require 'rake/packagetask'
 require 'rubygems/user_interaction'
-if RUBY_VERSION >= "2"
+begin
   require 'rubygems/package'
-else
+rescue LoadError
   require 'rubygems/builder'
 end
 

--- a/lib/bones/gem_package_task.rb
+++ b/lib/bones/gem_package_task.rb
@@ -47,7 +47,7 @@ class Bones::GemPackageTask < Rake::PackageTask
     file "#{package_dir_path}/#{gem_file}" => [package_dir_path] + package_files do
       when_writing("Creating GEM") {
         chdir(package_dir_path) do
-          if RUBY_VERSION >= "2"
+          if defined? Gem::Package.build
             Gem::Package.build(gem_spec)
           else
             Gem::Builder.new(gem_spec).build


### PR DESCRIPTION
`require 'rubygems/package'` will work for MRI > 2.0 as well as JRuby 1.7 which reports 1.9.3 compatibility but includes updated RubyGems

fixes #42 ... an alternative for the proposed fix at #44
