### PR TITLE
Fixing gem packaging on Ruby 3

### DIFF
--- a/lib/bones/gem_package_task.rb
+++ b/lib/bones/gem_package_task.rb
@@ -64,16 +64,12 @@ class Bones::GemPackageTask < Rake::PackageTask
     end
   end
 
-  #
-  #
   def gem_file
     if @gem_spec.platform == Gem::Platform::RUBY
-      "#{package_name}.gem"
+      "#{gem_spec.full_name}.gem"
     else
-      "#{package_name}-#{@gem_spec.platform}.gem"
+      "#{gem_spec.full_name}-#{gem_spec.platform}.gem"
     end
   end
+end
 
-end  # class Bones::GemPackageTask
-
-# EOF

--- a/lib/bones/plugins/bones_plugin.rb
+++ b/lib/bones/plugins/bones_plugin.rb
@@ -38,6 +38,13 @@ module Bones::Plugins::BonesPlugin
         most current release are included.
       __
 
+      license  nil, :desc => <<-__
+        This should just be the name of your license. The full text of the
+        license should be in a LICENSE file at the top-level of your gem when
+        you build it. The simplest way is to specify the standard SPDX ID
+        https://spdx.org/licenses/ for the license.
+      __
+
       authors  nil, :desc => <<-__
         This can be a single author (as a string) or an array of authors
         if more than one person is working on the project.
@@ -173,8 +180,6 @@ module Bones::Plugins::BonesPlugin
   end
 
   def define_tasks
-    config = ::Bones.config
-
     namespace :bones do
       desc 'Show the current Mr Bones configuration'
       task :debug do |t|
@@ -202,9 +207,7 @@ module Bones::Plugins::BonesPlugin
 
         ::Bones.help.show(atr, :descriptions => false, :values => false)
       end
-
-    end  # namespace :bones
+    end
   end
-
-end  # module Bones::Plugins::BonesPlugin
+end
 

--- a/lib/bones/plugins/gem.rb
+++ b/lib/bones/plugins/gem.rb
@@ -11,8 +11,7 @@ module Bones::Plugins::Gem
     # Adds the given gem _name_ to the current project's dependency list. An
     # optional gem _version_ can be given. If omitted, the newest gem version
     # will be used.
-    #
-    def depend_on( name, *args )
+    def depend_on(name, *args)
       opts = Hash === args.last ? args.pop : {}
       version = args.first || opts[:version]
       development = opts.key?(:development) ? opts[:development] : opts.key?(:dev) ? opts[:dev] : false
@@ -27,7 +26,7 @@ module Bones::Plugins::Gem
         spec = Gem.source_index.find_name(name).last
       end
 
-      version = ">= #{spec.version.to_s}" if version.nil? and !spec.nil?
+      version = "~> #{spec.version.to_s}" if version.nil? and !spec.nil?
 
       dep = case version
             when nil; [name]
@@ -40,9 +39,8 @@ module Bones::Plugins::Gem
       nil
     end
 
-    # Add the given _url_ to the list of gem sources.
-    #
-    def source( url )
+    # Add the given `url` to the list of gem sources.
+    def source(url)
       sources = ::Bones.config.gem.sources
       sources << url unless sources.include? url
       nil
@@ -133,7 +131,7 @@ module Bones::Plugins::Gem
     unless $bones_external_spec
       config.gem.files ||= manifest
       config.gem.executables ||= config.gem.files.find_all {|fn| fn =~ %r/^bin/}
-      config.gem.development_dependencies << ['bones', ">= #{Bones.version}"]
+      config.gem.development_dependencies << ['bones', "~> #{Bones.version}"]
     end
   end
 
@@ -149,8 +147,8 @@ module Bones::Plugins::Gem
           s.authors = Array(config.authors)
           s.email = config.email
           s.homepage = Array(config.url).first
-
           s.description = config.description
+          s.license = config.license
 
           config.gem.dependencies.each do |dep|
             s.add_dependency(*dep)
@@ -338,7 +336,7 @@ module Bones::Plugins::Gem
 
   # Import configuration from the given gemspec file.
   #
-  def import_gemspec( filename )
+  def import_gemspec(filename)
     $bones_external_spec = false
     spec = load_gemspec(filename)
     return if spec.nil?
@@ -356,6 +354,7 @@ module Bones::Plugins::Gem
     config.description        = spec.description
     config.files              = spec.files
     config.libs               = spec.require_paths
+    config.license            = spec.license
 
     config.gem.executables    = spec.executables
     if have? :rdoc
@@ -384,7 +383,7 @@ module Bones::Plugins::Gem
   # This method is stolen from the Bundler gem. It loads the gemspec from a
   # file if available.
   #
-  def load_gemspec( filename )
+  def load_gemspec(filename)
     path = Pathname.new(filename)
     # Eval the gemspec from its parent directory
     Dir.chdir(path.dirname) do
@@ -409,6 +408,5 @@ module Bones::Plugins::Gem
       end
     end
   end
-
-end  # Bones::Plugins::Gem
+end
 


### PR DESCRIPTION
Using the gem spec `full_name` when building and packaging gem files. The bones-git plugin is "smart" and adds a development version number to the gem package name which was not being handled properly.

Also adding support for a top-level `license` option.